### PR TITLE
Add dev page for component testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Donate to Educate Frontend
+# Donate to Educate Frontend
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
@@ -36,9 +36,9 @@ docker compose up
 
 If you want to run the vita preview server change the 'dockerfile' in [docker-compose.yml](./docker-compose.yml) to 'dockerfile-dev'
 
-# Components
+## Components
 
-## TextInput
+### TextInput
 
 A reusable text input component.
 
@@ -46,7 +46,7 @@ A reusable text input component.
 import TextInput from '@components/TextInput/TextInput';
 ```
 
-### Usage
+#### Usage
 
 The TextInput component can be used as follows:
 
@@ -59,7 +59,7 @@ The TextInput component can be used as follows:
 />
 ```
 
-### Props
+#### Props
 
 The TextInput component accepts the following props:
 
@@ -82,3 +82,51 @@ interface ValidationResult {
   errorMessage?: string;
 }
 ```
+
+## DevPreview Page
+
+The `DevPreview` page is a component preview tool for testing and previewing different components. It allows you to load and test new components before integrating them into a page. When the site is loaded using 'Development' as the NODE_ENV then a link will be available in the footer to the dev page.
+
+### How to Add a New Component to the DevPreview Page
+
+1. Create a new component file (e.g., `NewComponent.tsx`) in the appropriate directory.
+
+2. Import the new component in the `DevPreview.tsx` file:
+
+    ```tsx
+    import NewComponent from '@/path/to/NewComponent';
+    ```
+
+3. Import the necessary styles for the new component:
+
+    ```tsx
+    import NewComponentStyles from '@/path/to/NewComponent.module.scss';
+    ```
+
+4. Define the props interface for the new component, if necessary:
+
+    ```tsx
+    import { NewComponentProps } from '@/types/props';
+    ```
+
+5. Add the new component to the `DevPreview` component:
+
+    ```tsx
+    <Preview<NewComponentProps>
+      Component={NewComponent}
+      componentName="NewComponent"
+      initialProps={{
+        // Provide initial props for the new component
+      }}
+    />
+    ```
+
+6. Optionally, add any custom styles or classes specific to the new component:
+
+    ```tsx
+    import NewComponentStyles from '@/path/to/NewComponent.module.scss';
+    ```
+
+7. Save the changes and run the application to see the new component in the `DevPreview` page.
+
+By following these steps, you can easily add a new component to the `DevPreview` page for testing and previewing.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This template provides a minimal setup to get React working in Vite with HMR and
 
 Currently, two official plugins are available:
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- [@vitejs/plugin-react][1] uses [Babel][2] for Fast Refresh
+- [@vitejs/plugin-react-swc][3] uses [SWC][4] for Fast Refresh
 
 ## Expanding the ESLint configuration
 
@@ -24,7 +24,7 @@ If you are developing a production application, we recommend updating the config
 
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+- Install [eslint-plugin-react][5] and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
 
 ## Docker
 
@@ -34,11 +34,11 @@ Run the following command to build a docker container of the application. This w
 docker compose up
 ```
 
-If you want to run the vita preview server change the 'dockerfile' in [docker-compose.yml](./docker-compose.yml) to 'dockerfile-dev'
+If you want to run the vita preview server change the 'dockerfile' in [docker-compose.yml][6] to 'dockerfile-dev'
 
 ## Components
 
-### TextInput
+### [TextInput][7]
 
 A reusable text input component.
 
@@ -85,13 +85,13 @@ interface ValidationResult {
 
 ## DevPreview Page
 
-The `DevPreview` page is a component preview tool for testing and previewing different components. It allows you to load and test new components before integrating them into a page. When the site is loaded using 'Development' as the NODE_ENV then a link will be available in the footer to the dev page.
+The [`DevPreview`][8] page is a component preview tool for testing and previewing different components. It allows you to load and test new components before integrating them into a page. When the site is loaded using 'Development' as the NODE_ENV then a link will be available in the footer to the dev page.
 
 ### How to Add a New Component to the DevPreview Page
 
 1. Create a new component file (e.g., `NewComponent.tsx`) in the appropriate directory.
 
-2. Import the new component in the `DevPreview.tsx` file:
+2. Import the new component in the [`DevPreview.tsx`][8] file:
 
     ```tsx
     import NewComponent from '@/path/to/NewComponent';
@@ -109,7 +109,7 @@ The `DevPreview` page is a component preview tool for testing and previewing dif
     import { NewComponentProps } from '@/types/props';
     ```
 
-5. Add the new component to the `DevPreview` component:
+5. Add the new component to the `DevPreview` component by putting it inside a [Preview Component][9]:
 
     ```tsx
     <Preview<NewComponentProps>
@@ -129,4 +129,12 @@ The `DevPreview` page is a component preview tool for testing and previewing dif
 
 7. Save the changes and run the application to see the new component in the `DevPreview` page.
 
-By following these steps, you can easily add a new component to the `DevPreview` page for testing and previewing.
+[1]: https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md
+[2]: https://babeljs.io/
+[3]: https://github.com/vitejs/vite-plugin-react-swc
+[4]: https://swc.rs/
+[5]: https://github.com/jsx-eslint/eslint-plugin-react
+[6]: ./docker-compose.yml
+[7]: ./src/components//TextInput/TextInput.tsx
+[8]: ./src/pages/DevPreview/DevPreview.tsx
+[9]: ./src/components/DevPreview/Preview.tsx

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you are developing a production application, we recommend updating the config
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
 
 ## Docker
+
 Run the following command to build a docker container of the application. This will build the application then deploy a static server on the port '5173'
 
 ```cli
@@ -34,3 +35,50 @@ docker compose up
 ```
 
 If you want to run the vita preview server change the 'dockerfile' in [docker-compose.yml](./docker-compose.yml) to 'dockerfile-dev'
+
+# Components
+
+## TextInput
+
+A reusable text input component.
+
+```tsx
+import TextInput from '@components/TextInput/TextInput';
+```
+
+### Usage
+
+The TextInput component can be used as follows:
+
+```jsx
+<TextInput 
+  header="Your Header"
+  validator={yourValidatorFunction}
+  placeholder="Placeholder Text"
+  password={true}
+/>
+```
+
+### Props
+
+The TextInput component accepts the following props:
+
+- `header`: (string) The header text displayed above the input field.
+- `validator`: (function) A validation function that accepts the input value and returns an object with `isValid` (boolean) and `errorMessage` (string, optional) properties.
+- `placeholder`: (string, optional) Placeholder text to display in the input field.
+- `password`: (boolean, default = false) If `true`, displays the input field as a password input.
+
+#### Validator
+
+The validator on the text box is expecting a boolean result where false means it failed validation. There is also an error message expected to be returned which is then displayed as an error message on the component.
+
+```tsx
+import { ValidationResult } from '@/types/props'
+```
+
+```ts
+interface ValidationResult {
+  isValid: boolean;
+  errorMessage?: string;
+}
+```

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -25,6 +25,7 @@ $box-shadow-black: rgba(0, 0, 0, 0.1);
 // General Colours
 $black: black;
 $dark-blue: #050e33;
+$error-red: #f03a47;
 
 // Screen Breakpoints
 $screen-small: 400px;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,18 +1,21 @@
-import { FC, useState } from 'react';
+import { FC, useState, ChangeEvent } from 'react';
 import styles from './Checkbox.module.scss';
 import { CheckboxProps } from '@/types/props';
 import Checkmark from '@/assets/tiles/Checkmark';
 
-const Checkbox: FC<CheckboxProps> = ({ label, className }) => {
-  const [isChecked, setIsChecked] = useState(false);
+const Checkbox: FC<CheckboxProps> = ({ label, className, checked = false, onChange }) => {
+  const [isChecked, setIsChecked] = useState(checked);
+
+  const handleCheckboxChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setIsChecked(event.target.checked);
+    if (onChange) {
+      onChange(event.target.checked);
+    }
+  };
+
   return (
     <label>
-      <input
-        type="checkbox"
-        onChange={(): void => {
-          setIsChecked(!isChecked);
-        }}
-      />
+      <input type="checkbox" checked={isChecked} onChange={handleCheckboxChange} />
       <div tabIndex={1} className={`${styles.checkbox} ${className ?? ''}`}>
         <Checkmark isChecked={isChecked}></Checkmark>
       </div>
@@ -20,4 +23,5 @@ const Checkbox: FC<CheckboxProps> = ({ label, className }) => {
     </label>
   );
 };
+
 export default Checkbox;

--- a/src/components/DevPreview/Preview.module.scss
+++ b/src/components/DevPreview/Preview.module.scss
@@ -1,0 +1,9 @@
+.preview {
+  border: 1px solid black;
+  padding-bottom: 10px;
+  padding-left: 10px;
+}
+
+.dottedBorder {
+  border: 1px dotted black;
+}

--- a/src/components/DevPreview/Preview.tsx
+++ b/src/components/DevPreview/Preview.tsx
@@ -1,0 +1,53 @@
+import { useState, ChangeEvent } from 'react';
+import { PreviewProps, PropTypes } from '@/types/props';
+import styles from './Preview.module.scss';
+import Checkbox from '@components/Checkbox/Checkbox';
+
+export const Preview = <T extends PropTypes>({
+  Component,
+  componentName,
+  initialProps,
+}: PreviewProps<T>): JSX.Element => {
+  const [props, setProps] = useState<T>(initialProps);
+
+  const handleChange =
+    (key: keyof T) =>
+    (event: ChangeEvent<HTMLInputElement | (HTMLInputElement & { checked: boolean })>): void => {
+      setProps((prevProps) => ({ ...prevProps, [key]: event.target.value }));
+    };
+
+  return (
+    <div className={styles.preview}>
+      <h2>{componentName}</h2>
+      {Object.entries(initialProps).map(([key, value]) => (
+        <div key={key}>
+          <label>
+            {key}:
+            {typeof value === 'string' ? (
+              <input
+                type="text"
+                value={props[key as keyof T] as string}
+                onChange={handleChange(key as keyof T)}
+              />
+            ) : typeof value === 'boolean' ? (
+              <Checkbox
+                label={key}
+                checked={props[key as keyof T] as boolean}
+                onChange={(checked: boolean): void =>
+                  setProps((prevProps) => ({ ...prevProps, [key]: checked }))
+                }
+              />
+            ) : (
+              <div>{props[key as keyof T] as string}</div>
+            )}
+          </label>
+        </div>
+      ))}
+      <div className={styles.dottedBorder}>
+        <Component {...props} />
+      </div>
+    </div>
+  );
+};
+
+export default Preview;

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+import Footer from './Footer';
+
+// Mock the useNavigate hook
+jest.mock(
+  'react-router-dom',
+  (): Record<string, unknown> => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
+  })
+);
+
+// Mock the Button component
+jest.mock('../Button/Button', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(null),
+}));
+
+// Mock the LogoWhite component
+jest.mock('@assets/logo/LogoWhite', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(null),
+}));
+
+// Mock the WeHaveThePowerLogo image import
+jest.mock('../../assets/logo/WeHaveThePowerLogo.webp', () => ({
+  default: 'we-have-the-power-logo.webp',
+}));
+
+describe('Footer component', () => {
+  it('renders the "Dev Preview" link in development mode', () => {
+    // Set the environment to development
+    process.env.NODE_ENV = 'development';
+
+    // Provide a mock implementation for useNavigate
+
+    (useNavigate as jest.Mock<() => void>).mockImplementation(() => jest.fn());
+
+    // Render the Footer component within a MemoryRouter
+    const { getByText } = render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    // Verify that the "Dev Preview" link is present
+    expect(getByText('Dev Preview')).toBeInTheDocument();
+  });
+
+  it('does not render the "Dev Preview" link in non-development mode', () => {
+    // Set the environment to production
+    process.env.NODE_ENV = 'production';
+
+    (useNavigate as jest.Mock<() => void>).mockImplementation(() => jest.fn());
+
+    // Render the Footer component within a MemoryRouter
+    const { queryByText } = render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    // Verify that the "Dev Preview" link is not present
+    expect(queryByText('Dev Preview')).toBeNull();
+  });
+});

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -9,6 +9,9 @@ import WeHaveThePowerLogo from '../../assets/logo/WeHaveThePowerLogo.webp';
 
 const Footer: FC = () => {
   const navigate = useNavigate();
+
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
   return (
     <footer className={styles.footerContainer}>
       <div className={styles.container}>
@@ -25,6 +28,7 @@ const Footer: FC = () => {
           <Link to={Paths.ACCESSABILITY_STATEMENT}>Accessibility statement</Link>
           <Link to={Paths.PRIVACY_POLICY}>Privacy policy</Link>
           <Link to={Paths.TERMS_AND_CONDITIONS}>Terms and conditions</Link>
+          {isDevelopment && <Link to={String(Paths.DEV_PREVIEW)}>Dev Preview</Link>}
         </div>
         <p className={styles.copyrightNotice}>Donate to Educate &copy;</p>
       </div>

--- a/src/config/lazy.ts
+++ b/src/config/lazy.ts
@@ -8,6 +8,7 @@ const AccessabilityStatement = lazy(
 );
 const PrivacyPolicy = lazy(() => import('@pages/PrivacyPolicy/PrivacyPolicy'));
 const TermsAndConditions = lazy(() => import('@pages/TermsAndConditions/TermsAndConditions'));
+const DevPreview = lazy(() => import('@pages/DevPreview/DevPreview'));
 
 const NotFound = lazy(() => import('@pages/NotFound/NotFound'));
 
@@ -19,4 +20,5 @@ export {
   AccessabilityStatement,
   PrivacyPolicy,
   TermsAndConditions,
+  DevPreview,
 };

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -12,6 +12,7 @@ enum Paths {
   PTA = 'https://www.pta.co.uk/',
   FUNDED = 'https://www.funded.org.uk',
   INVENT = 'https://www.capgemini.com/about-us/who-we-are/our-brands/capgemini-invent/',
+  DEV_PREVIEW = '/6465762d70726576696577',
 }
 
 export default Paths;

--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -7,6 +7,7 @@ import {
   AccessabilityStatement,
   PrivacyPolicy,
   TermsAndConditions,
+  DevPreview,
 } from './lazy';
 
 const routes = [
@@ -36,6 +37,10 @@ const routes = [
   {
     path: Paths.TERMS_AND_CONDITIONS,
     element: <TermsAndConditions />,
+  },
+  {
+    path: Paths.DEV_PREVIEW,
+    element: <DevPreview />,
   },
   {
     path: Paths.DONATE,

--- a/src/pages/DevPreview/DevPreview.module.scss
+++ b/src/pages/DevPreview/DevPreview.module.scss
@@ -1,0 +1,4 @@
+@use '@assets/global.scss' as g;
+.background {
+  background-color: g.$primary-light-blue;
+}

--- a/src/pages/DevPreview/DevPreview.tsx
+++ b/src/pages/DevPreview/DevPreview.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import FooterPage from '@/components/FooterPage/FooterPage';
+import Modal from 'react-modal';
+import { Preview } from '@/components/DevPreview/Preview';
+
+//--- Components
+import TextInput from '@components/TextInput/TextInput';
+import Button from '@components/Button/Button';
+import Checkbox from '@/components/Checkbox/Checkbox';
+//--- Components
+
+//---Styles
+import ButtonStyles from '@components/Button/Button.module.scss';
+import CheckboxStyles from '@components/Checkbox/Checkbox.module.scss';
+import DevPreviewStyles from './DevPreview.module.scss';
+//---Styles
+
+//--- Component props
+import {
+  TextInputProps,
+  ValidationResult,
+  CheckboxProps,
+  ButtonProps,
+  Themes,
+} from '@/types/props';
+//--- Component props
+
+const DevPreview: React.FC = () => {
+  const validator: TextInputProps['validator'] = (input: string): ValidationResult => {
+    if (input.toLowerCase() === 'error') {
+      return {
+        isValid: false,
+        errorMessage: "Can't enter the word 'Error'",
+      };
+    }
+    return { isValid: true };
+  };
+
+  const buttonThemes = Object.keys(ButtonStyles).filter((className) => className !== 'disabled');
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+
+  const openModal = (): void => {
+    setModalIsOpen(true);
+    setTimeout(() => {
+      setModalIsOpen(false);
+    }, 1000);
+  };
+
+  const handleCheckboxChange = (checked: boolean): void => {
+    if (checked) {
+      openModal();
+    }
+  };
+
+  return (
+    <FooterPage title="Developer Componet Preview">
+      <div className={DevPreviewStyles.background}>
+        <Preview<TextInputProps>
+          Component={TextInput}
+          componentName="TextInput"
+          initialProps={{
+            header: 'Type Error for error',
+            validator: validator,
+            password: false,
+            subHeading: 'Sub Heading',
+          }}
+        />
+        {buttonThemes.map((className) => (
+          <Preview<ButtonProps>
+            key={className}
+            Component={Button}
+            componentName={`Button ${className}`}
+            initialProps={{
+              onClick: openModal,
+              text: className,
+              theme: className as Themes,
+            }}
+          />
+        ))}
+        <Preview<CheckboxProps>
+          Component={Checkbox}
+          componentName="Checkbox"
+          initialProps={{
+            label: 'CheckBox',
+            className: CheckboxStyles.checkbox,
+            onChange: handleCheckboxChange,
+          }}
+        />
+        <Modal isOpen={modalIsOpen}>
+          <h2>Modal Shown</h2>
+        </Modal>
+      </div>
+    </FooterPage>
+  );
+};
+
+export default DevPreview;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,6 +1,26 @@
-import { ReactNode } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import { CarouselItem } from './data';
 
+// Add your new props export here so it can be used in the devPreview
+export type PropTypes =
+  | LayoutProps
+  | ButtonProps
+  | ImageProps
+  | ErrorBoundaryProps
+  | SvgProps
+  | HeaderProps
+  | NavLinksProps
+  | ClickableLogoProps
+  | CheckboxProps
+  | CheckmarkProps
+  | RadioButtonProps
+  | RadioGroupProps
+  | InfoTileProps
+  | CarouselProps
+  | FooterPageProps
+  | TextInputProps;
+
+//-------
 export interface LayoutProps {
   header?: ReactNode;
   footer?: ReactNode;
@@ -56,6 +76,8 @@ export interface ClickableLogoProps {
 export interface CheckboxProps {
   label?: string;
   className?: string;
+  checked?: boolean;
+  onChange?: (e: boolean) => void;
 }
 
 export interface CheckmarkProps {
@@ -104,4 +126,11 @@ export interface TextInputProps {
   password?: boolean;
   id?: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+// ------ Dev only props
+export interface PreviewProps<T> {
+  Component: ComponentType<T>;
+  componentName: string;
+  initialProps: T;
 }


### PR DESCRIPTION
This adds a link in the footer which should only show up when the server is in 'Development' This allows you to render your components and see them working without needing a specific page to load them up on.