### PR TITLE
Feat: use user inputs on local authority sign up

### DIFF
--- a/src/pages/AdminDashboard/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard/AdminDashboard.tsx
@@ -164,6 +164,9 @@ const AdminDashboard: FC = () => {
                             theme="link"
                             text="Add user"
                             onClick={(): void => {
+                              // eslint-disable-next-line no-console
+                              console.log('test message!!!');
+
                               setSelectedLa(la.name);
                               setStage('la_sign_up');
                             }}
@@ -193,7 +196,7 @@ const AdminDashboard: FC = () => {
         <ConfirmationPage
           setStage={setStage}
           icon={<Email />}
-          title="You have created an account for West Sussex County Council"
+          title={`You have created an account for ${selectedLa} County Council`}
           message={<p>The main user has been emailed with instructions to set up their profile</p>}
         />
       )}

--- a/src/pages/AdminDashboard/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard/AdminDashboard.tsx
@@ -164,9 +164,6 @@ const AdminDashboard: FC = () => {
                             theme="link"
                             text="Add user"
                             onClick={(): void => {
-                              // eslint-disable-next-line no-console
-                              console.log('test message!!!');
-
                               setSelectedLa(la.name);
                               setStage('la_sign_up');
                             }}

--- a/src/pages/AdminDashboard/LocalAuthoritySignUp.tsx
+++ b/src/pages/AdminDashboard/LocalAuthoritySignUp.tsx
@@ -1,5 +1,5 @@
 import TextInput from '@/components/TextInput/TextInput';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import styles from './LocalAuthoritySignUp.module.scss';
 import FormButton from '@/components/FormButton/FormButton';
 import TextArea from '@/components/TextArea/TextArea';
@@ -15,6 +15,17 @@ interface LocalAuthoritySignUpProps {
 }
 
 const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage }) => {
+  const [localState, setLocalState] = useState({
+    name: name,
+    firstName: '',
+    lastName: '',
+    jobTitle: '',
+    department: '',
+    email: '',
+    phone: '',
+    notes: '',
+  });
+
   const { refetch } = useQuery({
     queryKey: ['register'],
     enabled: false,
@@ -22,13 +33,14 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       const result = await client.graphql<GraphQLQuery<RegisterLocalAuthorityMutation>>({
         query: registerLocalAuthority,
         variables: {
-          name,
-          firstName: '1',
-          lastName: '2',
-          jobTitle: '1',
-          department: '1',
-          email: '1',
-          phone: '1',
+          name: name,
+          firstName: localState.firstName,
+          lastName: localState.lastName,
+          jobTitle: localState.jobTitle,
+          department: localState.department,
+          email: localState.email,
+          phone: localState.phone,
+          notes: localState.notes,
         },
       });
 
@@ -40,13 +52,67 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
     <div className={styles.card}>
       <h1>{name}</h1>
       <hr />
-      <TextInput header="First name" />
-      <TextInput header="Last name" />
-      <TextInput header="Job title or role" />
-      <TextInput header="Department" />
-      <TextInput header="Email" />
-      <TextInput header="Phone" />
+      <TextInput
+        header="First name"
+        onChange={(event) => {
+          setLocalState((prevState) => ({
+            ...prevState,
+            firstName: event.target.value,
+          }));
+        }}
+      />
+      <TextInput
+        header="Last name"
+        onChange={(event) => {
+          setLocalState((prevState) => ({
+            ...prevState,
+            lastName: event.target.value,
+          }));
+        }}
+      />
+      <TextInput
+        header="Job title or role"
+        onChange={(event) => {
+          setLocalState((prevState) => ({
+            ...prevState,
+            jobTitle: event.target.value,
+          }));
+        }}
+      />
+      <TextInput
+        header="Department"
+        onChange={(event) => {
+          setLocalState((prevState) => ({
+            ...prevState,
+            department: event.target.value,
+          }));
+        }}
+      />
+      <TextInput
+        header="Email"
+        onChange={(event) => {
+          setLocalState((prevState) => ({
+            ...prevState,
+            email: event.target.value,
+          }));
+        }}
+      />
+      <TextInput
+        header="Phone"
+        onChange={(event) => {
+          setLocalState((prevState) => ({
+            ...prevState,
+            phone: event.target.value,
+          }));
+        }}
+      />
       <TextArea
+        onChange={(event) => {
+          setLocalState((prevState) => ({
+            ...prevState,
+            notes: event.target.value,
+          }));
+        }}
         header="Notes about this user (optional)"
         subHeading="This information can only be seen by Donate to Educate administrators."
         characterLimit={1000}

--- a/src/pages/AdminDashboard/LocalAuthoritySignUp.tsx
+++ b/src/pages/AdminDashboard/LocalAuthoritySignUp.tsx
@@ -15,8 +15,8 @@ interface LocalAuthoritySignUpProps {
 }
 
 const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage }) => {
-  const [localState, setLocalState] = useState({
-    name: name,
+  const [formState, setFormState] = useState({
+    name,
     firstName: '',
     lastName: '',
     jobTitle: '',
@@ -33,14 +33,14 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       const result = await client.graphql<GraphQLQuery<RegisterLocalAuthorityMutation>>({
         query: registerLocalAuthority,
         variables: {
-          name: name,
-          firstName: localState.firstName,
-          lastName: localState.lastName,
-          jobTitle: localState.jobTitle,
-          department: localState.department,
-          email: localState.email,
-          phone: localState.phone,
-          notes: localState.notes,
+          name,
+          firstName: formState.firstName,
+          lastName: formState.lastName,
+          jobTitle: formState.jobTitle,
+          department: formState.department,
+          email: formState.email,
+          phone: formState.phone,
+          notes: formState.notes,
         },
       });
 
@@ -55,7 +55,7 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       <TextInput
         header="First name"
         onChange={(event) => {
-          setLocalState((prevState) => ({
+          setFormState((prevState) => ({
             ...prevState,
             firstName: event.target.value,
           }));
@@ -64,7 +64,7 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       <TextInput
         header="Last name"
         onChange={(event) => {
-          setLocalState((prevState) => ({
+          setFormState((prevState) => ({
             ...prevState,
             lastName: event.target.value,
           }));
@@ -73,7 +73,7 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       <TextInput
         header="Job title or role"
         onChange={(event) => {
-          setLocalState((prevState) => ({
+          setFormState((prevState) => ({
             ...prevState,
             jobTitle: event.target.value,
           }));
@@ -82,7 +82,7 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       <TextInput
         header="Department"
         onChange={(event) => {
-          setLocalState((prevState) => ({
+          setFormState((prevState) => ({
             ...prevState,
             department: event.target.value,
           }));
@@ -91,7 +91,7 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       <TextInput
         header="Email"
         onChange={(event) => {
-          setLocalState((prevState) => ({
+          setFormState((prevState) => ({
             ...prevState,
             email: event.target.value,
           }));
@@ -100,7 +100,7 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       <TextInput
         header="Phone"
         onChange={(event) => {
-          setLocalState((prevState) => ({
+          setFormState((prevState) => ({
             ...prevState,
             phone: event.target.value,
           }));
@@ -108,7 +108,7 @@ const LocalAuthoritySignUp: FC<LocalAuthoritySignUpProps> = ({ name, setStage })
       />
       <TextArea
         onChange={(event) => {
-          setLocalState((prevState) => ({
+          setFormState((prevState) => ({
             ...prevState,
             notes: event.target.value,
           }));


### PR DESCRIPTION
This update changes the code so the actual values from the user's input on the local authority sign up page are sent to the backend