### PR TITLE
add real local authority names to charity sign up page dropdown

### DIFF
--- a/src/components/MultiStepForm/MultiStepForm.tsx
+++ b/src/components/MultiStepForm/MultiStepForm.tsx
@@ -7,8 +7,9 @@ import FormButton from '@/components/FormButton/FormButton';
 import BackButton from '@/components/BackButton/BackButton';
 import Button from '@/components/Button/Button';
 import { useNavigate } from 'react-router-dom';
+import Spinner from '../Spinner/Spinner';
 
-const FormContainer: FC<MultiStepFormProps> = ({ formTemplate, formData }) => {
+const FormContainer: FC<MultiStepFormProps> = ({ formTemplate, formData, isLoading = false }) => {
   const navigate = useNavigate();
   const [navigationFromCya, setNavigationFromCya] = useState(false);
   const [pageNumber, setPageNumber] = useState(0);
@@ -63,56 +64,62 @@ const FormContainer: FC<MultiStepFormProps> = ({ formTemplate, formData }) => {
   return (
     <div>
       <BackButton onClick={onBackButtonClick} theme="blue" />
-      <div className={`${styles.formContainer} ${isLastPage ? styles.lastPageContainer : ''}`}>
-        {pageNumber > 0 && (
-          <div className={styles.pagination}>
-            Step {pageNumber} of {formTemplate.length - 1}
-          </div>
-        )}
-        {logo && <div className={styles.logoContainer}>{logo}</div>}
-        <div className={styles.headerContainer}>
-          {header && <h2 className={styles.header}>{header}</h2>}
-          {subHeader && <h4 className={styles.subHeader}>{subHeader}</h4>}
-        </div>
-        {formComponents.map(
-          ({ componentType, componentData, formComponentLink, classNameSuffix }, index) => (
-            <div
-              className={`${styles.formComponent} ${
-                classNameSuffix ? styles[classNameSuffix] : ''
-              }`}
-              key={index}
-            >
-              {createFormComponent(componentType, formData, componentData, setPageNumber)}
-              {formComponentLink && (
-                <div className={styles.link}>
-                  <ExternalLink {...formComponentLink} />
-                </div>
-              )}
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <div className={`${styles.formContainer} ${isLastPage ? styles.lastPageContainer : ''}`}>
+          {pageNumber > 0 && (
+            <div className={styles.pagination}>
+              Step {pageNumber} of {formTemplate.length - 1}
             </div>
-          )
-        )}
-        {isLastPage ? (
-          <div className={styles.returnHomeLink}>
-            <Button theme={'link'} text={'Return to homepage'} onClick={returnHome} />
+          )}
+          {logo && <div className={styles.logoContainer}>{logo}</div>}
+          <div className={styles.headerContainer}>
+            {header && <h2 className={styles.header}>{header}</h2>}
+            {subHeader && <h4 className={styles.subHeader}>{subHeader}</h4>}
           </div>
-        ) : cyaPageNumber && pageNumber < cyaPageNumber ? (
-          <FormButton
-            text={pageNumber === 0 ? 'Start' : 'Next'}
-            theme={'formButtonDarkBlue'}
-            onClick={onButtonClick}
-            useArrow={true}
-          />
-        ) : (
-          <FormButton
-            text={'Confirm'}
-            theme={
-              cyaPageNumber && pageNumber > cyaPageNumber ? 'formButtonDarkBlue' : 'formButtonGrey'
-            }
-            onClick={onButtonClick}
-            useArrow={true}
-          />
-        )}
-      </div>
+          {formComponents.map(
+            ({ componentType, componentData, formComponentLink, classNameSuffix }, index) => (
+              <div
+                className={`${styles.formComponent} ${
+                  classNameSuffix ? styles[classNameSuffix] : ''
+                }`}
+                key={index}
+              >
+                {createFormComponent(componentType, formData, componentData, setPageNumber)}
+                {formComponentLink && (
+                  <div className={styles.link}>
+                    <ExternalLink {...formComponentLink} />
+                  </div>
+                )}
+              </div>
+            )
+          )}
+          {isLastPage ? (
+            <div className={styles.returnHomeLink}>
+              <Button theme={'link'} text={'Return to homepage'} onClick={returnHome} />
+            </div>
+          ) : cyaPageNumber && pageNumber < cyaPageNumber ? (
+            <FormButton
+              text={pageNumber === 0 ? 'Start' : 'Next'}
+              theme={'formButtonDarkBlue'}
+              onClick={onButtonClick}
+              useArrow={true}
+            />
+          ) : (
+            <FormButton
+              text={'Confirm'}
+              theme={
+                cyaPageNumber && pageNumber > cyaPageNumber
+                  ? 'formButtonDarkBlue'
+                  : 'formButtonGrey'
+              }
+              onClick={onButtonClick}
+              useArrow={true}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/SignUpCharity/SignUpCharity.tsx
+++ b/src/pages/SignUpCharity/SignUpCharity.tsx
@@ -13,7 +13,7 @@ import LogoBlue from '@/assets/logo/LogoBlue';
 import SchoolQuestion from '@/assets/Form/SchoolQuestion';
 import LogoWhite from '@/assets/logo/LogoWhite';
 import { client } from '@/graphqlClient';
-import { GetLocalAuthoritiesQuery, GetJoinRequestsQuery } from '@/types/api';
+import { GetLocalAuthoritiesQuery } from '@/types/api';
 import { useQuery } from '@tanstack/react-query';
 import { GraphQLQuery } from 'aws-amplify/api';
 import { getLocalAuthorities } from '@/graphql/queries';
@@ -30,9 +30,7 @@ const SignUpCharity: FC = () => {
   const { data, isLoading, error } = useQuery({
     queryKey: ['la'],
     queryFn: async () => {
-      const { data } = await client.graphql<
-        GraphQLQuery<GetLocalAuthoritiesQuery & GetJoinRequestsQuery>
-      >({
+      const { data } = await client.graphql<GraphQLQuery<GetLocalAuthoritiesQuery>>({
         query: getLocalAuthorities,
       });
 
@@ -41,12 +39,12 @@ const SignUpCharity: FC = () => {
   });
 
   if (error) {
-    throw new Error();
+    throw new Error('Failed to fetch LocalAuthorities data.');
   }
 
-  const options = data?.getLocalAuthorities.map((option) => ({
-    value: option.code,
-    label: option.name,
+  const options = data?.getLocalAuthorities.map(({ code, name }) => ({
+    value: code,
+    label: name,
   }));
 
   const formTemplate: FormTemplate[] = [
@@ -99,7 +97,7 @@ const SignUpCharity: FC = () => {
           componentType: ComponentType.DROPDOWN,
           componentData: {
             subHeading: 'If you have locations across the country, choose one main local council.',
-            options: options,
+            options,
             isLarge: true,
             formMeta: {
               page: 2,

--- a/src/pages/SignUpCharity/SignUpCharity.tsx
+++ b/src/pages/SignUpCharity/SignUpCharity.tsx
@@ -12,6 +12,11 @@ import {
 import LogoBlue from '@/assets/logo/LogoBlue';
 import SchoolQuestion from '@/assets/Form/SchoolQuestion';
 import LogoWhite from '@/assets/logo/LogoWhite';
+import { client } from '@/graphqlClient';
+import { GetLocalAuthoritiesQuery, GetJoinRequestsQuery } from '@/types/api';
+import { useQuery } from '@tanstack/react-query';
+import { GraphQLQuery } from 'aws-amplify/api';
+import { getLocalAuthorities } from '@/graphql/queries';
 
 const SignUpCharity: FC = () => {
   const [formData, setFormData] = useState<FormDataItem[]>([]);
@@ -21,6 +26,28 @@ const SignUpCharity: FC = () => {
     const removeOldValue = formData.filter(({ field: oldField }) => oldField !== field);
     setFormData([...removeOldValue, { field, value, section, page }]);
   };
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['la'],
+    queryFn: async () => {
+      const { data } = await client.graphql<
+        GraphQLQuery<GetLocalAuthoritiesQuery & GetJoinRequestsQuery>
+      >({
+        query: getLocalAuthorities,
+      });
+
+      return data;
+    },
+  });
+
+  if (error) {
+    throw new Error();
+  }
+
+  const options = data?.getLocalAuthorities.map((option) => ({
+    value: option.code,
+    label: option.name,
+  }));
 
   const formTemplate: FormTemplate[] = [
     {
@@ -72,11 +99,7 @@ const SignUpCharity: FC = () => {
           componentType: ComponentType.DROPDOWN,
           componentData: {
             subHeading: 'If you have locations across the country, choose one main local council.',
-            options: [
-              { value: 'westBerks', label: 'West Berkshire' },
-              { value: 'westNorthants', label: 'West Northamptonshire' },
-              { value: 'westSussex', label: 'West Sussex County Council' },
-            ],
+            options: options,
             isLarge: true,
             formMeta: {
               page: 2,
@@ -338,7 +361,7 @@ const SignUpCharity: FC = () => {
 
   return (
     <div className={styles.container}>
-      <MultiStepForm formTemplate={formTemplate} formData={formData} />
+      <MultiStepForm formTemplate={formTemplate} formData={formData} isLoading={isLoading} />
     </div>
   );
 };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -161,6 +161,7 @@ export interface TextInputProps extends CommonInputProps {
 export interface MultiStepFormProps {
   formTemplate: FormTemplate[];
   formData: FormDataItem[];
+  isLoading?: boolean;
 }
 export interface DropdownProps extends CommonInputProps {
   options: DropdownOption[];


### PR DESCRIPTION
This PR pertains to issue [#C3](https://trello.com/c/YjT2Sobi/112-c3-what-is-the-name-of-your-charity-or-volunteer-groups-local-council) on the Trello board, view [C3](https://www.figma.com/file/CkrBbFX2QQqIv0jdjOd4IR/Donate-to-Educate-%2F-Prototype?node-id=2512%3A153032&mode=dev) on the Figma board, and allows the user to select real local council names obtained from an API call.