### PR TITLE
Add form input validation to charity sign up page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-router-dom": "^6.21.3",
         "react-select": "^5.8.0",
         "react-verification-input": "^4.1.0",
+        "validator": "^13.11.0",
         "vite-plugin-node-polyfills": "^0.19.0",
         "zod": "^3.22.4"
       },
@@ -32,6 +33,7 @@
         "@types/react-dom": "^18.2.18",
         "@types/react-highlight-words": "^0.16.7",
         "@types/react-test-renderer": "^18.0.7",
+        "@types/validator": "^13.11.8",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
         "@vitejs/plugin-react-swc": "^3.5.0",
@@ -4819,6 +4821,12 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
       "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g=="
+    },
+    "node_modules/@types/validator": {
+      "version": "13.11.8",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
+      "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -13390,6 +13398,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-router-dom": "^6.21.3",
     "react-select": "^5.8.0",
     "react-verification-input": "^4.1.0",
+    "validator": "^13.11.0",
     "vite-plugin-node-polyfills": "^0.19.0",
     "zod": "^3.22.4"
   },
@@ -48,6 +49,7 @@
     "@types/react-dom": "^18.2.18",
     "@types/react-highlight-words": "^0.16.7",
     "@types/react-test-renderer": "^18.0.7",
+    "@types/validator": "^13.11.8",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/src/components/BackButton/BackButton.tsx
+++ b/src/components/BackButton/BackButton.tsx
@@ -9,7 +9,11 @@ const BackButton: FC<Pick<ButtonProps, 'onClick' | 'className'> & { theme: 'whit
   theme,
 }) => {
   return (
-    <button className={`${styles.back} ${className ?? ''} ${styles[theme]}`} onClick={onClick}>
+    <button
+      className={`${styles.back} ${className ?? ''} ${styles[theme]}`}
+      onClick={onClick}
+      type="button"
+    >
       <ChevronLeft colour={theme} />
       <h4>Back</h4>
     </button>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -33,6 +33,7 @@ const Dropdown: FC<DropdownProps> = ({
         onChange={handleSelect}
         value={dropDownValue}
         placeholder={value}
+        required={!header?.includes('optional')}
       />
     </div>
   );

--- a/src/components/MultiStepForm/MultiStepForm.module.scss
+++ b/src/components/MultiStepForm/MultiStepForm.module.scss
@@ -22,6 +22,21 @@
     margin-bottom: 60px;
   }
 
+  .errorMessage {
+    color: g.$error-red;
+    font-weight: 700;
+    color: g.$error-red;
+    margin-top: 0;
+    margin-bottom: 20px;
+    text-decoration: underline;
+  }
+
+  .wrapperError {
+    border: 5px solid g.$error-red;
+    padding-left: 20px;
+    margin-bottom: 20px;
+  }
+
   .headerContainer {
     margin: 0 0 40px;
     color: g.$primary-dark-blue;

--- a/src/components/MultiStepForm/MultiStepForm.tsx
+++ b/src/components/MultiStepForm/MultiStepForm.tsx
@@ -40,17 +40,17 @@ const FormContainer: FC<MultiStepFormProps> = ({ formTemplate, formData, isLoadi
     }
   }, [header, pageNumber]);
 
-  const onButtonClick = (e: FormEvent<Element>): void => {
-    e.preventDefault();
+  const onButtonClick = (event: FormEvent<Element>): void => {
+    event.preventDefault();
 
-    const errors: Record<string, string> = {};
-    for (const component of formComponents) {
-      const { formMeta: { field = '' } = {} } = component.componentData as CommonInputProps;
+    const errors = formComponents.reduce((acc: Record<string, string>, { componentData }) => {
+      const { formMeta: { field = '' } = {} } = componentData as CommonInputProps;
       const error = validateFormInputField(formData, field);
       if (error) {
-        errors[field] = error;
+        acc[field] = error;
       }
-    }
+      return acc;
+    }, {});
 
     if (Object.keys(errors).length > 0) {
       setFormErrors(errors);
@@ -112,11 +112,9 @@ const FormContainer: FC<MultiStepFormProps> = ({ formTemplate, formData, isLoadi
           </div>
           {formComponents.map(
             ({ componentType, componentData, formComponentLink, classNameSuffix }, index) => {
-              let errorMessage;
               const { formMeta: { field = '' } = {} } = componentData as CommonInputProps;
-              if (field in formErrors) {
-                errorMessage = formErrors[field];
-              }
+              const errorMessage = field in formErrors ? formErrors[field] : '';
+
               return (
                 <div
                   className={`${styles.formComponent} ${

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -34,6 +34,7 @@ const TextArea: FC<TextAreaProps> = ({
         onChange={handleChange}
         className={styles.textArea}
         placeholder={placeholder ?? ''}
+        maxLength={1000}
       />
       <div className={styles.characterCount}>
         <span>

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -50,7 +50,11 @@
   margin-bottom: 20px;
 }
 
-.wrapper.error {
+.errorInput {
+  border-color: g.$error-red;
+}
+
+.wrapperError {
   border-left: 5px solid g.$error-red;
   padding-left: 20px;
 }

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -14,6 +14,7 @@ const TextInput: FC<TextInputProps> = ({
   formMeta,
   value,
   disabled = false,
+  errorMessage,
 }) => {
   const [inputType, setInputType] = useState('password');
 
@@ -32,9 +33,12 @@ const TextInput: FC<TextInputProps> = ({
   };
 
   return (
-    <div className={styles.wrapper}>
+    <div className={`${styles.wrapper}  ${errorMessage ? styles.wrapperError : ''}`}>
       {header && <h4 className={styles.header}>{header}</h4>}
       {subHeading && <h5 className={styles.subHeading}>{subHeading}</h5>}
+      {errorMessage && (
+        <h5 className={`${styles.subHeading} ${styles.errorMessage}`}>{errorMessage}</h5>
+      )}
       {password && <ShowHide onChangePasswordVisibility={handleChangePasswordVisibility} />}
       <input
         type={password ? inputType : 'text'}
@@ -42,9 +46,10 @@ const TextInput: FC<TextInputProps> = ({
         onChange={handleChange}
         className={`${styles.input} ${isLarge ? styles.inputLarge : ''} ${
           isSmall ? styles.inputSmall : ''
-        }`}
+        } ${errorMessage ? styles.errorInput : ''}`}
         placeholder={placeholder ?? ''}
         disabled={disabled}
+        required={!header?.includes('optional')}
       />
     </div>
   );

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -1,3 +1,0 @@
-export const EMAIL_ERROR_MESSAGE =
-  'Enter the email address in the correct format, like team@donatetoeducate.org.uk';
-export const PHONE_ERROR_MESSAGE = 'Enter the phone number in the correct format, like 07123456789';

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -1,0 +1,3 @@
+export const EMAIL_ERROR_MESSAGE =
+  'Enter the email address in the correct format, like team@donatetoeducate.org.uk';
+export const PHONE_ERROR_MESSAGE = 'Enter the phone number in the correct format, like 07123456789';

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -73,6 +73,11 @@ export enum FormNames {
   SCHOOL = 'Sign up school',
 }
 
+export enum FormErrors {
+  EMAIL_ERROR_MESSAGE = 'Enter the email address in the correct format, like team@donatetoeducate.org.uk',
+  PHONE_ERROR_MESSAGE = 'Enter the phone number in the correct format, like 07123456789',
+}
+
 export enum ComponentType {
   TEXT = 'textInput',
   CHECKBOX = 'checkbox',

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -34,7 +34,7 @@ export interface ButtonProps {
 
 export interface FormButtonProps {
   theme: FormButtonThemes;
-  onClick?: (e: FormEvent<Element>) => void;
+  onClick?: (event: FormEvent<Element>) => void;
   text: string | JSX.Element;
   useArrow?: boolean;
   fullWidth?: boolean;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,4 +1,4 @@
-import { Dispatch, ReactNode, SetStateAction } from 'react';
+import { Dispatch, FormEvent, ReactNode, SetStateAction } from 'react';
 import {
   CarouselItem,
   DropdownOption,
@@ -34,7 +34,7 @@ export interface ButtonProps {
 
 export interface FormButtonProps {
   theme: FormButtonThemes;
-  onClick: () => void;
+  onClick?: (e: FormEvent<Element>) => void;
   text: string | JSX.Element;
   useArrow?: boolean;
   fullWidth?: boolean;
@@ -152,6 +152,7 @@ export interface CommonInputProps {
   formMeta?: FormMeta;
   value?: string;
   disabled?: boolean;
+  errorMessage?: string;
 }
 
 export interface TextInputProps extends CommonInputProps {

--- a/src/utils/components.tsx
+++ b/src/utils/components.tsx
@@ -25,7 +25,8 @@ export const createFormComponent = (
   componentType: ComponentType,
   formData: FormDataItem[],
   componentData?: ComponentDataPropsType,
-  setPageNumber?: Dispatch<SetStateAction<number>>
+  setPageNumber?: Dispatch<SetStateAction<number>>,
+  errorMessage?: string
 ): ReactNode => {
   const { formMeta: { field = '' } = {} } = componentData as CommonInputProps;
 
@@ -34,7 +35,13 @@ export const createFormComponent = (
     case ComponentType.INTRO:
       return <FormIntroPage {...(componentData as FormIntroPageProps)} />;
     case ComponentType.TEXT:
-      return <TextInput {...(componentData as TextInputProps)} value={String(value)} />;
+      return (
+        <TextInput
+          {...(componentData as TextInputProps)}
+          value={String(value)}
+          errorMessage={errorMessage}
+        />
+      );
     case ComponentType.TEXTAREA:
       return <TextArea {...(componentData as TextAreaProps)} value={String(value)} />;
     case ComponentType.RADIO:

--- a/src/utils/formUtils.tsx
+++ b/src/utils/formUtils.tsx
@@ -1,5 +1,8 @@
+import { EMAIL_ERROR_MESSAGE, PHONE_ERROR_MESSAGE } from '@/config/errors';
 import { DropdownOption, FormDataItem, FormNames, FormSections } from '@/types/data';
 import { SingleValue } from 'react-select';
+import isEmail from 'validator/lib/isEmail';
+import isMobilePhone from 'validator/lib/isMobilePhone';
 
 const excludedValues = [
   'First name',
@@ -16,6 +19,28 @@ export const findValueFromFormData = (
   fieldName: string
 ): string | number | boolean => {
   return formData.find(({ field }) => field === fieldName)?.value ?? '';
+};
+
+export const validateFormInputField = (
+  formData: FormDataItem[],
+  fieldName: string
+): string | null => {
+  const value = formData.find(({ field }) => field === fieldName)?.value ?? '';
+  if (typeof value === 'string') {
+    switch (fieldName) {
+      case 'Email':
+        if (!isEmail(value)) {
+          return EMAIL_ERROR_MESSAGE;
+        }
+        break;
+      case 'Phone':
+        if (!isMobilePhone(value, 'en-GB')) {
+          return PHONE_ERROR_MESSAGE;
+        }
+        break;
+    }
+  }
+  return null;
 };
 
 const addressBuilder = (formData: FormDataItem[]): string => {

--- a/src/utils/formUtils.tsx
+++ b/src/utils/formUtils.tsx
@@ -1,5 +1,4 @@
-import { EMAIL_ERROR_MESSAGE, PHONE_ERROR_MESSAGE } from '@/config/errors';
-import { DropdownOption, FormDataItem, FormNames, FormSections } from '@/types/data';
+import { DropdownOption, FormDataItem, FormErrors, FormNames, FormSections } from '@/types/data';
 import { SingleValue } from 'react-select';
 import isEmail from 'validator/lib/isEmail';
 import isMobilePhone from 'validator/lib/isMobilePhone';
@@ -30,12 +29,12 @@ export const validateFormInputField = (
     switch (fieldName) {
       case 'Email':
         if (!isEmail(value)) {
-          return EMAIL_ERROR_MESSAGE;
+          return FormErrors.EMAIL_ERROR_MESSAGE;
         }
         break;
       case 'Phone':
         if (!isMobilePhone(value, 'en-GB')) {
-          return PHONE_ERROR_MESSAGE;
+          return FormErrors.PHONE_ERROR_MESSAGE;
         }
         break;
     }


### PR DESCRIPTION
This PR pertains to [this ticket on the Trello board ](https://trello.com/c/U55gWYLN/188-add-validation-to-the-charity-sign-up-multi-form) and [this design on the Figma board](https://www.figma.com/file/CkrBbFX2QQqIv0jdjOd4IR/Donate-to-Educate-%2F-Prototype?node-id=3794%3A34399&mode=dev).

### Main changes:
- Users will be prevented from progressing to the next page if they have not filled out a required input, as shown below (_**note: the only inputs that are not required are those with "optional" in the header**_):

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/53f42368-1ea7-4083-9a67-337c736990ed)

- Users will be given specific error messages if they have filled out email or phone number inputs incorrectly, i.e. typing 
_**johndoe&gmail.com**_ instead of **_johndoe@gmail.com_**, or providing a phone number that does not conform to UK standards (is this ok? or are we expecting people to sign up with non-UK numbers?).

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/554ec13c-530f-4f94-82da-e5377a66cdec)

- Users are now prevented from entering more than 1000 characters within a `TextArea` component, as shown below (I know in recent discussions we spoke about how to handle this behaviour, and if I recall correctly, one idea was to let the users exceed the character limit but then disallow form submission and change the text colour to red? I am happy to change this as required):

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/c7c54f84-5a45-46df-948e-bda505e588cc)
