### PR TITLE
center verification input within reset password screen

### DIFF
--- a/src/pages/Login/ResetPassword/ResetPassword.module.scss
+++ b/src/pages/Login/ResetPassword/ResetPassword.module.scss
@@ -26,11 +26,12 @@
   }
 
   .verificationCodeInputContainer {
-    width: 30em;
+    width: auto;
     display: flex;
     align-items: center;
     flex-direction: column;
     padding: 20px;
+    margin: 0 auto;
   }
 }
 


### PR DESCRIPTION
Trello ticket link: https://trello.com/c/44cLLETS/532-reset-password-verification-screen-needs-centralising

Nice easy one to review, changed reset password screen from this:

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/8ee96ed3-5f8b-4423-95b5-def27d44d7a9)

to this:

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/bd240b5b-5708-485b-9443-cba8eca3c6ad)


hurray for margin: 0 auto