### PR TITLE
Remove empty items from requested product types

### DIFF
--- a/src/components/AddressInset/AddressInset.tsx
+++ b/src/components/AddressInset/AddressInset.tsx
@@ -6,11 +6,12 @@ import styles from './AddressInset.module.scss';
 const AddressInset: FC<AddressInsetProps> = ({ componentData, formData }) => {
   const { formMeta: { field = '' } = {} } = componentData as CommonInputProps;
   const data = findFullValueFromFormData(formData, field);
+  const { name, localAuthority, postcode } = data ?? {};
 
-  if (!data) {
+  if (!name && !localAuthority && !postcode) {
     return <></>;
   }
-  const { name, localAuthority, postcode } = data;
+
   return (
     <div className={styles.container}>
       {!!name && <p>{String(name)}</p>}

--- a/src/components/ItemList/ItemListEdit.tsx
+++ b/src/components/ItemList/ItemListEdit.tsx
@@ -11,6 +11,16 @@ interface ItemListEditProps {
 
 const ItemListEdit: FC<ItemListEditProps> = ({ setItems, items }) => {
   const [allSelectedNames, setAllSelectedNames] = useState<string[]>([]);
+
+  const removeEmptyItems = (items: Record<number, string[]>): Record<number, string[]> => {
+    for (const categoryNumber in items) {
+      if (items[categoryNumber].length === 0) {
+        delete items[categoryNumber];
+      }
+    }
+    return items;
+  };
+
   const handleToggle = (value: boolean, itemKey: string, name: SectionsIconType): void => {
     const categoryNumber = convertCategoryToNumber(name);
     setItems((previousItems) => {
@@ -24,7 +34,7 @@ const ItemListEdit: FC<ItemListEditProps> = ({ setItems, items }) => {
       }
 
       const newItems = currentItems.filter((item) => item !== itemKey);
-      return { ...previousItems, [categoryNumber]: newItems };
+      return removeEmptyItems({ ...previousItems, [categoryNumber]: newItems });
     });
   };
 

--- a/src/pages/FindYourCommunity/YourLocalArea/DonateAndExcess/DonateAndExcess.tsx
+++ b/src/pages/FindYourCommunity/YourLocalArea/DonateAndExcess/DonateAndExcess.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import styles from './DonateAndExcess.module.scss';
 import BackButton from '@/components/BackButton/BackButton';
 import { convertMilesToMeters } from '@/utils/distance';
@@ -28,9 +28,11 @@ const DonateAndExcess: FC<DonateAndExcessProps> = ({ type, postcode, hasState })
     data: charityData,
     isLoading: charityLoading,
     isError: isErrorCharity,
+    refetch: charityRefetch,
   } = useQuery({
     queryKey: [`getCharitiesNearby-${postcode}-${maxDistance}-${type}`],
     enabled: hasState,
+    refetchOnWindowFocus: true,
     queryFn: async () => {
       const { data } = await client.graphql<GraphQLQuery<GetCharitiesNearbyWithProfileQuery>>({
         query: getCharitiesNearbyWithProfile,
@@ -49,9 +51,11 @@ const DonateAndExcess: FC<DonateAndExcessProps> = ({ type, postcode, hasState })
     data: schoolData,
     isLoading: schoolLoading,
     isError: isErrorSchool,
+    refetch: schoolRefetch,
   } = useQuery({
     queryKey: [`getSchoolsNearby-${postcode}-${maxDistance}-${type}`],
     enabled: hasState,
+    refetchOnWindowFocus: true,
     queryFn: async () => {
       const { data } = await client.graphql<GraphQLQuery<GetSchoolsNearbyWithProfileQuery>>({
         query: getSchoolsNearbyWithProfile,
@@ -65,6 +69,11 @@ const DonateAndExcess: FC<DonateAndExcessProps> = ({ type, postcode, hasState })
       return data;
     },
   });
+
+  useEffect(() => {
+    void charityRefetch();
+    void schoolRefetch();
+  }, [schoolRefetch, charityRefetch]);
 
   if (charityLoading || schoolLoading || !hasState) {
     return <Spinner />;

--- a/src/pages/FindYourCommunity/YourLocalArea/FindCharity/FindCharityTable.tsx
+++ b/src/pages/FindYourCommunity/YourLocalArea/FindCharity/FindCharityTable.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { convertMilesToMeters } from '@/utils/distance';
 import { GetCharitiesNearbyWithProfileQuery } from '@/types/api';
 import { GraphQLQuery } from 'aws-amplify/api';
@@ -13,9 +13,10 @@ import { FindCharityTableProps } from '@/types/props';
 const maxDistance = convertMilesToMeters(10);
 
 const FindCharityTable: FC<FindCharityTableProps> = ({ title, postcode, type }) => {
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: [`getCharitiesNearby-${postcode}-${maxDistance}-request`],
     enabled: true,
+    refetchOnWindowFocus: true,
     queryFn: async () => {
       const { data } = await client.graphql<GraphQLQuery<GetCharitiesNearbyWithProfileQuery>>({
         query: getCharitiesNearbyWithProfile,
@@ -29,6 +30,10 @@ const FindCharityTable: FC<FindCharityTableProps> = ({ title, postcode, type }) 
       return data;
     },
   });
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
 
   if (isLoading) {
     return <Spinner />;

--- a/src/pages/FindYourCommunity/YourLocalArea/FindSchool/FindSchool.tsx
+++ b/src/pages/FindYourCommunity/YourLocalArea/FindSchool/FindSchool.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import styles from './FindSchool.module.scss';
 import BackButton from '@/components/BackButton/BackButton';
 import { Link } from 'react-router-dom';
@@ -24,9 +24,9 @@ const FindSchool: FC = () => {
     Paths.FIND_YOUR_COMMUNITY
   );
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: [`getSchoolsNearby-${state.postcode}-${maxDistance}-request`],
-    enabled: hasState,
+    enabled: true,
     queryFn: async () => {
       const { data } = await client.graphql<GraphQLQuery<GetSchoolsNearbyWithProfileQuery>>({
         query: getSchoolsNearbyWithProfile,
@@ -40,6 +40,10 @@ const FindSchool: FC = () => {
       return data;
     },
   });
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
 
   if (isLoading || !hasState) {
     return <Spinner />;


### PR DESCRIPTION
This PR pertains to the following Trello ticket: https://trello.com/c/sQAddfjy/536-if-i-uncheck-a-whole-category-section-eg-computing-and-technology-then-the-icon-doesnt-seem-to-disappear-in-the-product-types-av

This change will make sure that if a school admin unticks all items within a certain category, i.e. "Computing and Technology", this category will no longer appear within the "Product types available" column when users search for that school, as shown beflow:


**With Computing and Technology items ticked:**

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/122ac2ea-ad9d-4632-aa83-7b346affb68b)

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/5df5c63c-5864-432e-8709-69b14c6a3f59)

**Without Computing and Technology items ticked:**

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/485efd58-9f77-4f0a-8bb0-0bc272261956)

![image](https://github.com/CapgeminiInventUK/donate-to-educate-frontend/assets/10779091/b5157b72-50fb-46fa-a7cf-b1108cc14f29)