### PR TITLE
allow users to enter landline phones when signing up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "aws-amplify": "6.1.4",
         "framer-motion": "11.1.7",
         "is-ci": "3.0.1",
+        "phone": "^3.1.43",
         "react": "18.3.0",
         "react-dom": "18.3.0",
         "react-highlight-words": "0.20.0",
@@ -11685,6 +11686,14 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/phone": {
+      "version": "3.1.43",
+      "resolved": "https://registry.npmjs.org/phone/-/phone-3.1.43.tgz",
+      "integrity": "sha512-R4UT/3fIXJUHFko7WpOtHj4YYUIUwRIs1VKCMf74gLfiq6QczDBy3S/Ihy0MG1Sc4KcylvnQgIOMQGfQ6T6/3A==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "aws-amplify": "6.1.4",
     "framer-motion": "11.1.7",
     "is-ci": "3.0.1",
+    "phone": "^3.1.43",
     "react": "18.3.0",
     "react-dom": "18.3.0",
     "react-highlight-words": "0.20.0",

--- a/src/components/MultiStepForm/MultiStepForm.tsx
+++ b/src/components/MultiStepForm/MultiStepForm.tsx
@@ -122,10 +122,10 @@ const FormContainer: FC<MultiStepFormProps> = ({
 
     setFormErrors({});
 
-    const phoneNumberIndex = formData.findIndex(({ field }) => field.toLowerCase() === 'phone');
+    const phoneNumberIndex = formData.findIndex(({ field }) => field?.toLowerCase() === 'phone');
     const phoneNumber = formData[phoneNumberIndex];
     if (phoneNumber) {
-      const formattedPhoneNumber = formatPhoneNumber(phoneNumber.value as string);
+      const formattedPhoneNumber = formatPhoneNumber(String(phoneNumber.value));
       if (formattedPhoneNumber) {
         formData[phoneNumberIndex].value = formattedPhoneNumber;
       }

--- a/src/components/MultiStepForm/MultiStepForm.tsx
+++ b/src/components/MultiStepForm/MultiStepForm.tsx
@@ -5,7 +5,7 @@ import BackButton from '@/components/BackButton/BackButton';
 import { useNavigate } from 'react-router-dom';
 import Spinner from '@/components/Spinner/Spinner';
 import { SummaryPageColour, FormErrors, ComponentType } from '@/types/data';
-import { validateFormInputField } from '@/utils/formUtils';
+import { formatPhoneNumber, validateFormInputField } from '@/utils/formUtils';
 import SchoolAlreadyRegistered from '@/components/SchoolAlreadyRegistered/SchoolAlreadyRegistered';
 import Card from '../Card/Card';
 import { useQueryClient } from '@tanstack/react-query';
@@ -121,6 +121,15 @@ const FormContainer: FC<MultiStepFormProps> = ({
     }
 
     setFormErrors({});
+
+    const phoneNumberIndex = formData.findIndex(({ field }) => field.toLowerCase() === 'phone');
+    const phoneNumber = formData[phoneNumberIndex];
+    if (phoneNumber) {
+      const formattedPhoneNumber = formatPhoneNumber(phoneNumber.value as string);
+      if (formattedPhoneNumber) {
+        formData[phoneNumberIndex].value = formattedPhoneNumber;
+      }
+    }
 
     if (onLocalAuthorityRegisterRequest) {
       return onLocalAuthorityRegisterRequest();

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -92,7 +92,7 @@ export enum FormNames {
 
 export enum FormErrors {
   EMAIL_ERROR_MESSAGE = 'Enter the email address in the correct format, like team@donatetoeducate.org.uk',
-  PHONE_ERROR_MESSAGE = 'Enter the phone number in the correct format, like 07123456789',
+  PHONE_ERROR_MESSAGE = 'Enter a UK phone number in the correct format, like 07123456789',
   POSTCODE_ERROR_MESSAGE = 'Enter the postcode in the correct format, like LL70 9DJ',
   POSTCODE_NOT_FOUND = 'Postcode not found',
   TEXTAREA_MAX_LENGTH = 'Enter no more than 1000 characters',

--- a/src/utils/formUtils.tsx
+++ b/src/utils/formUtils.tsx
@@ -10,6 +10,7 @@ import { SingleValue } from 'react-select';
 import { isLength, isPostalCode } from 'validator';
 import isEmail from 'validator/lib/isEmail';
 import { phone } from 'phone';
+import { phoneNumberRegex } from './globals';
 
 const excludedValues = [
   'First name',
@@ -55,7 +56,7 @@ export const validateFormInputField = (
         break;
       case 'phone':
         if (
-          !/^[+]?[0-9\s]+$/.test(value) || // Regex to check inputted phone number contains only digits, spaces or a "+" at the beginning
+          !phoneNumberRegex.test(value) ||
           !phone(value, { country: 'GBR', validateMobilePrefix: false }).isValid
         ) {
           return FormErrors.PHONE_ERROR_MESSAGE;

--- a/src/utils/formUtils.tsx
+++ b/src/utils/formUtils.tsx
@@ -9,7 +9,7 @@ import {
 import { SingleValue } from 'react-select';
 import { isLength, isPostalCode } from 'validator';
 import isEmail from 'validator/lib/isEmail';
-import isMobilePhone from 'validator/lib/isMobilePhone';
+import { phone } from 'phone';
 
 const excludedValues = [
   'First name',
@@ -54,7 +54,10 @@ export const validateFormInputField = (
         }
         break;
       case 'phone':
-        if (!isMobilePhone(value, 'en-GB')) {
+        if (
+          !/^[+]?[0-9\s]+$/.test(value) || // Regex to check inputted phone number contains only digits, spaces or a "+" at the beginning
+          !phone(value, { country: 'GBR', validateMobilePrefix: false }).isValid
+        ) {
           return FormErrors.PHONE_ERROR_MESSAGE;
         }
         break;
@@ -67,6 +70,13 @@ export const validateFormInputField = (
     }
   }
   return null;
+};
+
+export const formatPhoneNumber = (phoneNumber: string): string | null => {
+  return phone(phoneNumber, {
+    country: 'GBR',
+    validateMobilePrefix: false,
+  }).phoneNumber;
 };
 
 const addressBuilder = (formData: FormDataItem[]): string => {

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -13,3 +13,6 @@ export const scrollToTheTop = (): void => {
     behavior: 'smooth',
   });
 };
+
+// Regex to check inputted phone number contains only digits, spaces or a "+" at the beginning
+export const phoneNumberRegex = /^[+]?[0-9\s]+$/;


### PR DESCRIPTION
This PR pertains to this Trello ticket: https://trello.com/c/SGKZ07Zv/570-users-are-unable-to-add-in-a-landline-number-when-trying-to-register-as-a-school-or-charity, and adds the ability for users to input landline phone numbers (for example, 01934 123 456) rather than only mobile numbers.