### PR TITLE
Fix page navigation bug on save and added 'next steps' header to section

### DIFF
--- a/src/pages/Charity/Admin/CharityEdit.tsx
+++ b/src/pages/Charity/Admin/CharityEdit.tsx
@@ -252,6 +252,7 @@ const CharityEdit: FC = () => {
             <ItemListEdit setItems={setItems} items={items} />
 
             <div className={styles.helpContact}>
+              <h2>Next steps</h2>
               {!editStateActionText ? (
                 <>
                   <p>{content.actionText}</p>

--- a/src/pages/School/Admin/SchoolEdit.tsx
+++ b/src/pages/School/Admin/SchoolEdit.tsx
@@ -237,9 +237,7 @@ const SchoolEdit: FC = () => {
                   }}
                   handleSave={() => {
                     setEditState(false);
-                    void refetch().then(() => {
-                      navigate(-1);
-                    });
+                    void refetch();
                   }}
                   handleCancel={() => {
                     setContent({ ...content, whatToExpect: whatToExpectTestBeforeEdit });


### PR DESCRIPTION
https://trello.com/c/jWTHR6sc/605-when-i-click-save-on-the-what-to-expect-tile-it-routes-me-to-the-profile-screen-ideally-this-should-not-happen