### PR TITLE
fix: use correct save button styling

### DIFF
--- a/src/components/EditableInformationTile/EditableInformationTile.tsx
+++ b/src/components/EditableInformationTile/EditableInformationTile.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import styles from './EditableInformationTile.module.scss';
-import Button from '../Button/Button';
 import { EditableInformationTileProps } from '@/types/props';
 import HorizontalLine from '@/assets/school/HorizontalLine';
 import TextArea from '../TextArea/TextArea';
@@ -27,8 +26,8 @@ const EditableInformationTile: FC<EditableInformationTileProps> = ({
           <>
             <TextArea characterLimit={1000} onChange={setText} value={text} ariaLabel="edit" />
             <div className={styles.footerButtons}>
-              <Button
-                theme="darkBlue"
+              <FormButton
+                theme="formButtonGreen"
                 className={styles.saveButton}
                 onClick={saveOnClick}
                 text="Save"


### PR DESCRIPTION
This PR addresses [issue 574](https://e-3d-dc1.capgemini.com/jira/browse/DC0518-574) and implements the correct styling for the save button shown while editing the "About us" section on a school/charity page.

Save button now looks like this, which is more in-line with our figma designs:

![image](https://github.com/user-attachments/assets/0d8f2b51-daca-4261-baf9-d998e6e9f10b)

[figma designs](https://www.figma.com/design/CkrBbFX2QQqIv0jdjOd4IR/Donate-to-Educate-%2F-Prototype?node-id=5054-78585&m=dev):

![image](https://github.com/user-attachments/assets/0edf26c9-3ed2-454e-bdbb-01b0c8fd9bf9)


To test locally, spin up front end, login, access http://localhost:5173/school-admin-create-profile and click "edit" button within "About us" section.

