### PR TITLE
feat: Clickable error summary

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,4 @@ sonar.organization=capgeminiinventuk
 sonar.projectKey=CapgeminiInventUK_donate-to-educate-frontend
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.coverage.exclusions=**/__test__/*.test.*

--- a/src/components/FormErrors/FormErrors.tsx
+++ b/src/components/FormErrors/FormErrors.tsx
@@ -4,14 +4,29 @@ import { FormErrorsProps } from '@/types/props';
 import { checkIfValidObjectWithData } from '@/utils/globals';
 
 const FormErrors: FC<FormErrorsProps> = ({ formErrors }) => {
+  const scrollToElement = (
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    key: string
+  ): void => {
+    e.preventDefault();
+
+    document.getElementById(key)?.focus();
+  };
+
   return (
     checkIfValidObjectWithData(formErrors) && (
       <div className={styles.wrapperError}>
         <h3>There is a problem</h3>
-        {Object.values(formErrors).map((error) => (
-          <h4 className={styles.errorMessage} key={error}>
-            {error}
-          </h4>
+        {Object.keys(formErrors).map((key) => (
+          <a
+            href={`#${key}`}
+            className={styles.errorMessage}
+            data-testid={`${key}`}
+            key={formErrors[key]}
+            onClick={(e) => scrollToElement(e, key)}
+          >
+            <h4>{formErrors[key]}</h4>
+          </a>
         ))}
       </div>
     )

--- a/src/components/FormErrors/FormErrors.tsx
+++ b/src/components/FormErrors/FormErrors.tsx
@@ -21,7 +21,6 @@ const FormErrors: FC<FormErrorsProps> = ({ formErrors }) => {
           <a
             href={`#${key}`}
             className={styles.errorMessage}
-            data-testid={`${key}`}
             key={formErrors[key]}
             onClick={(e) => scrollToElement(e, key)}
           >

--- a/src/components/FormErrors/__test__/FormErrors.test.tsx
+++ b/src/components/FormErrors/__test__/FormErrors.test.tsx
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { render } from '@testing-library/react';
 import FormErrors from '../FormErrors';
 
@@ -14,5 +15,19 @@ describe('Form Errors', () => {
   it('should render error list when errors present', () => {
     const { queryByText } = render(<FormErrors formErrors={errors} />);
     expect(queryByText('There is a problem')).toBeInTheDocument();
+  });
+
+  it('should focus text field when error is clicked', () => {
+    const { getByTestId } = render(<FormErrors formErrors={errors} />);
+    const clickableError = getByTestId('testField');
+    const mockInputElement = { focus: vi.fn() };
+    vi.spyOn(document, 'getElementById').mockReturnValue(
+      mockInputElement as unknown as HTMLElement
+    );
+
+    clickableError.click();
+
+    expect(clickableError).toBeInTheDocument();
+    expect(mockInputElement.focus).toHaveBeenCalled();
   });
 });

--- a/src/components/FormErrors/__test__/FormErrors.test.tsx
+++ b/src/components/FormErrors/__test__/FormErrors.test.tsx
@@ -18,8 +18,8 @@ describe('Form Errors', () => {
   });
 
   it('should focus text field when error is clicked', () => {
-    const { getByTestId } = render(<FormErrors formErrors={errors} />);
-    const clickableError = getByTestId('testField');
+    const { getByRole } = render(<FormErrors formErrors={errors} />);
+    const clickableError = getByRole('link', { name: errors.testField });
     const mockInputElement = { focus: vi.fn() };
     vi.spyOn(document, 'getElementById').mockReturnValue(
       mockInputElement as unknown as HTMLElement

--- a/src/components/MultiStepForm/MultiStepForm.tsx
+++ b/src/components/MultiStepForm/MultiStepForm.tsx
@@ -80,7 +80,11 @@ const FormContainer: FC<MultiStepFormProps> = ({
     event.preventDefault();
     scrollToTheTop();
 
-    await validateMultiStepForm(formComponents, formData, setFormErrors, queryClient);
+    const valid = await validateMultiStepForm(formComponents, formData, setFormErrors, queryClient);
+
+    if (!valid) {
+      return;
+    }
 
     if (onLocalAuthorityRegisterRequest) {
       return onLocalAuthorityRegisterRequest();

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -59,6 +59,7 @@ const TextInput: FC<TextInputProps> = ({
           disabled={disabled}
           required={!header?.includes('optional')}
           aria-label={ariaLabel}
+          id={ariaLabel}
         />
       </div>
     </div>

--- a/src/utils/formValidationUtils.ts
+++ b/src/utils/formValidationUtils.ts
@@ -115,18 +115,20 @@ export const validateMultiStepForm = async (
   formData: FormDataItem[],
   setFormErrors: Dispatch<SetStateAction<Record<string, string>>>,
   queryClient?: QueryClient
-): Promise<void> => {
+): Promise<boolean> => {
   const errors = getFormErrors(formComponents, formData);
   queryClient && (await validatePostcodeAndAddToFormErrors(queryClient, errors, formData));
 
   if (Object.keys(errors).length > 0) {
     setFormErrors((formErrors) => ({ ...formErrors, ...errors }));
-    return;
+    return false;
   }
 
   setFormErrors({});
 
   parsePhoneNumber(formData);
+
+  return true;
 };
 
 export const validateForm = (formState: RequestFormState | FormState): Record<string, string> => {


### PR DESCRIPTION
- Clicking or focussing + hitting enter on the error summary entry will now focus the input element the error is referring to

## Demo
![d2e-skip-to-error](https://github.com/user-attachments/assets/abdbc319-3c79-4951-92ff-7cfcc3cf6910)
