### PR TITLE
chore: minor styling tweaks

### DIFF
--- a/src/components/EditDescription/EditDescription.module.scss
+++ b/src/components/EditDescription/EditDescription.module.scss
@@ -5,6 +5,7 @@
 }
 
 .cancelButton {
-  margin: 4px 0 0 20px;
+  margin: 4px 0 0 10px;
+  font-size: 1.2rem;
   color: g.$secondary-mid-blue;
 }

--- a/src/components/EditableInformationTile/EditableInformationTile.module.scss
+++ b/src/components/EditableInformationTile/EditableInformationTile.module.scss
@@ -59,6 +59,7 @@
 }
 
 .footerButtons {
+  margin-top: -3rem;
   display: flex;
   width: 50rem;
   align-items: center;

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -16,7 +16,7 @@ const TextArea: FC<TextAreaProps> = ({
   value,
   ariaLabel,
 }) => {
-  const [characterCount, setCharacterCount] = useState(0);
+  const [characterCount, setCharacterCount] = useState(value?.length ?? 0);
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
     const inputValue = event.target.value;


### PR DESCRIPTION
This PR addresses [issue 611](https://e-3d-dc1.capgemini.com/jira/browse/DC0518-611) and implements a few styling tweaks.

Changes:

- **"About us" section within "/school-admin-create-profile" now shows correct character count in bottom right immediately upon mount, and "Save" and "Cancel" buttons are slightly higher up**

<img width="1064" alt="image" src="https://github.com/user-attachments/assets/d49bbd4f-2283-4d2a-ac64-d7dda096e6d8">

- **"What to expect" within "/school-admin-edit" now also shows correct character count, and "Cancel" button is slightly bigger**

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/7e13cb49-e2eb-404c-80dd-4a05cc1609a2">

- **"Next steps" within "/school-admin-edit" now also shows correct character count, and "Cancel" button is slightly bigger**

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/c58b0936-e416-4079-b9c4-a266442bac1c">

