### PR TITLE
fix: fix mobile responsiveness issue

### DIFF
--- a/src/components/TextInputSearch/TextInputSearch.module.scss
+++ b/src/components/TextInputSearch/TextInputSearch.module.scss
@@ -44,7 +44,7 @@
   }
 
   @include g.md-breakpoint {
-    max-width: 50%;
+    max-width: 40%;
   }
 }
 


### PR DESCRIPTION
This PR addresses a minor mobile responsiveness issue, see below:

Before (notice how the search bar slightly goes outside the grey box):

![image](https://github.com/user-attachments/assets/16df7e34-ad48-4415-9b95-44054d4e9d0d)


After:

![image](https://github.com/user-attachments/assets/68af1bd7-6153-49a2-a168-a480d5a1ba2d)
