### PR TITLE
fix: use correct link for local authority 'contact us' button

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -45,7 +45,7 @@ const Login: FC = () => {
             <h3>If you work for a local authority</h3>
             <p>
               If you work for a local authority and want to join,{' '}
-              <Link className={styles.link} to={Paths.CONTACT}>
+              <Link className={styles.link} to={Paths.LOCAL_AUTHORITY_JOIN_INFO}>
                 {' '}
                 contact us.{' '}
               </Link>


### PR DESCRIPTION
This PR addresses the following ticket: https://e-3d-dc1.capgemini.com/jira/browse/DC0518-622