### PR TITLE
feat: Only show other charities under 'Other nearby charities'

### DIFF
--- a/src/components/PublicDashboard/PublicDashboard.tsx
+++ b/src/components/PublicDashboard/PublicDashboard.tsx
@@ -64,7 +64,7 @@ const PublicDashboard: FC<PublicDashboardProps> = ({ type, profile, setPreview, 
         {postcode && (
           <div className={styles.nearbyCharitiesTable}>
             <hr />
-            <FindCharityTable postcode={postcode} type={type} />
+            <FindCharityTable postcode={postcode} type={type} currentCharityId={id} />
           </div>
         )}
         {setPreview && (

--- a/src/pages/FindYourCommunity/YourLocalArea/FindCharity/FindCharityTable.tsx
+++ b/src/pages/FindYourCommunity/YourLocalArea/FindCharity/FindCharityTable.tsx
@@ -16,7 +16,12 @@ import { InstitutionType } from '@/types/data';
 
 const maxDistance = convertMilesToMetres(SEARCH_RADIUS_IN_MILES);
 
-const FindCharityTable: FC<FindCharityTableProps> = ({ title, postcode, type }) => {
+const FindCharityTable: FC<FindCharityTableProps> = ({
+  title,
+  postcode,
+  type,
+  currentCharityId,
+}) => {
   const location = useLocation();
 
   const { data, isLoading, isError, refetch } = useQuery({
@@ -50,12 +55,12 @@ const FindCharityTable: FC<FindCharityTableProps> = ({ title, postcode, type }) 
     return <ErrorBanner />;
   }
 
-  const charitiesRows = (data?.getCharitiesNearbyWithProfile?.results ?? []).map(
-    (charity, key) => ({
+  const charitiesRows = (data?.getCharitiesNearbyWithProfile?.results ?? [])
+    .filter((charity) => charity.id !== currentCharityId)
+    .map((charity, key) => ({
       ...charity,
       key,
-    })
-  );
+    }));
 
   return (
     <>

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -580,6 +580,7 @@ export interface FindCharityTableProps {
   title?: string;
   postcode: string;
   type?: InstitutionType;
+  currentCharityId?: string;
 }
 
 export interface LocationStateOrRedirectProps<T> {


### PR DESCRIPTION
- Prevent the current charity being seen under 'Other nearby charities' on the charities profile page

Connects to DC0518-569

Example: (The current charity profile is Oxfam, which isn't visible under 'Other nearby charities')
![image](https://github.com/user-attachments/assets/0dc4c1b5-ca00-4f62-976f-fc51257a5d85)
