### PR TITLE
feat: Hide empty 'nearby charities' table on school profile page

### DIFF
--- a/src/pages/FindYourCommunity/YourLocalArea/FindCharity/FindCharityTable.tsx
+++ b/src/pages/FindYourCommunity/YourLocalArea/FindCharity/FindCharityTable.tsx
@@ -64,34 +64,40 @@ const FindCharityTable: FC<FindCharityTableProps> = ({
 
   return (
     <>
-      {title ? (
-        <h1>{title}</h1>
-      ) : type === InstitutionType.SCHOOL ? (
-        <h2>Nearby charities who can also help</h2>
-      ) : (
-        <h2>Other nearby charities who can also help</h2>
-      )}
-      <ProductsTable
-        tableData={charitiesRows}
-        type={InstitutionType.CHARITY}
-        iconColour="#97C8EB"
-        productsColumnHeader="Product types available"
-        postcode={postcode}
-      />
-      {location.pathname.includes('your-local-area') && (
+      {charitiesRows?.length > 0 ? (
         <>
-          <h3>Charity map</h3>
-          <Map
-            initialCoordinates={
-              data?.getCharitiesNearbyWithProfile?.searchLocation?.coordinates ?? [0, 0]
-            }
-            markers={charitiesRows.map(({ location: { coordinates }, name }) => ({
-              coordinates,
-              name,
-              colour: '#11356F',
-            }))}
+          {title ? (
+            <h1>{title}</h1>
+          ) : type === InstitutionType.SCHOOL ? (
+            <h2>Nearby charities who can also help</h2>
+          ) : (
+            <h2>Other nearby charities who can also help</h2>
+          )}
+          <ProductsTable
+            tableData={charitiesRows}
+            type={InstitutionType.CHARITY}
+            iconColour="#97C8EB"
+            productsColumnHeader="Product types available"
+            postcode={postcode}
           />
+          {location.pathname.includes('your-local-area') && (
+            <>
+              <h3>Charity map</h3>
+              <Map
+                initialCoordinates={
+                  data?.getCharitiesNearbyWithProfile?.searchLocation?.coordinates ?? [0, 0]
+                }
+                markers={charitiesRows.map(({ location: { coordinates }, name }) => ({
+                  coordinates,
+                  name,
+                  colour: '#11356F',
+                }))}
+              />
+            </>
+          )}
         </>
+      ) : (
+        <></>
       )}
     </>
   );


### PR DESCRIPTION
- Hide empty 'nearby charities' table on school profile page

Connects to DC0518-600

Before:
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/0c0d4775-91df-4279-ba0b-614b2b8d7bd3">


After:
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/9687175b-896b-44a9-a344-127e6df03ea1">
