### PR TITLE
feat: Change content for Incomplete Profile

### DIFF
--- a/src/components/IncompleteProfile/IncompleteProfile.module.scss
+++ b/src/components/IncompleteProfile/IncompleteProfile.module.scss
@@ -1,0 +1,18 @@
+@use "@assets/global.scss" as g;
+
+.bannerContainer {
+  background: g.$primary-dark-blue;
+  color: g.$primary-white;
+  padding: 30px 40px;
+  border-top: g.$secondary-blue 18px solid;
+  border-radius: 10px 10px 0 0;
+
+  a {
+    color: g.$primary-white;
+    text-decoration: underline;
+
+    &:focus, &:hover {
+      color: g.$primary-light-blue;
+    }
+  }
+}

--- a/src/components/IncompleteProfile/IncompleteProfile.tsx
+++ b/src/components/IncompleteProfile/IncompleteProfile.tsx
@@ -1,0 +1,23 @@
+import Paths from '@/config/paths';
+import styles from './IncompleteProfile.module.scss';
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+const IncompleteProfile: FC = () => {
+  return (
+    <div className={`${styles.bannerContainer}`}>
+      <h2>We are still populating our profile</h2>
+
+      <p>
+        <span>Check back later or you can also </span>
+        <Link to={Paths.LOCAL_CHARITIES}>find nearby charities who may be able to help.</Link>
+      </p>
+
+      <p>
+        <Link to={Paths.CONTACT}>Contact us</Link> if you need help
+      </p>
+    </div>
+  );
+};
+
+export default IncompleteProfile;

--- a/src/components/PublicDashboard/PublicDashboard.tsx
+++ b/src/components/PublicDashboard/PublicDashboard.tsx
@@ -8,6 +8,7 @@ import FindCharityTable from '@/pages/FindYourCommunity/YourLocalArea/FindCharit
 import { returnObjectValueOrUndefined, scrollToTheTop } from '@/utils/globals';
 import { PublicDashboardProps } from '@/types/props';
 import ActionTiles from './PublicDashboardActionTiles';
+import IncompleteProfile from '../IncompleteProfile/IncompleteProfile';
 
 const PublicDashboard: FC<PublicDashboardProps> = ({ type, profile, setPreview, previewMode }) => {
   const { header, name, about, excess, donate, request, id, postcode } = profile ?? {};
@@ -23,52 +24,59 @@ const PublicDashboard: FC<PublicDashboardProps> = ({ type, profile, setPreview, 
     scrollToTheTop();
   }, [name]);
 
+  const isProfileIncomplete = (): boolean => {
+    return !(about ?? excess ?? donate ?? request);
+  };
+
   return (
     <>
-      <InstitutionBanner type={type} name={name} banner={banner} isPublic={true} />
-      <Card className={styles.dashboardCard}>
-        {!(about ?? excess ?? donate ?? request) && (
-          <p>We are still populating our profile, please check back later</p>
-        )}
-        {about && (
-          <div className={styles.aboutContainer}>
-            <div className={styles.titleContainer}>
-              <h2>About us</h2>
-              <div className={styles.svgContainer}>
-                <HorizontalLine className={styles.horizontalLine} />
+      {!previewMode && isProfileIncomplete() ? (
+        <IncompleteProfile />
+      ) : (
+        <>
+          <InstitutionBanner type={type} name={name} banner={banner} isPublic={true} />
+          <Card className={styles.dashboardCard}>
+            {about && (
+              <div className={styles.aboutContainer}>
+                <div className={styles.titleContainer}>
+                  <h2>About us</h2>
+                  <div className={styles.svgContainer}>
+                    <HorizontalLine className={styles.horizontalLine} />
+                  </div>
+                </div>
+                <p className={styles.paragraph}>{about}</p>
               </div>
-            </div>
-            <p className={styles.paragraph}>{about}</p>
-          </div>
-        )}
-        <ActionTiles
-          request={request}
-          donate={donate}
-          excess={excess}
-          type={type}
-          name={name ?? ''}
-          id={id ?? ''}
-          previewMode={previewMode}
-          postcode={postcode}
-        />
-        {postcode && (
-          <div className={styles.nearbyCharitiesTable}>
-            <hr />
-            <FindCharityTable postcode={postcode} type={type} currentCharityId={id} />
-          </div>
-        )}
-        {setPreview && (
-          <div className={styles.actionButtons}>
-            <FormButton
-              theme="formButtonGrey"
-              text="Edit profile"
-              ariaLabel="edit profile"
-              fullWidth={true}
-              onClick={() => setPreview(false)}
+            )}
+            <ActionTiles
+              request={request}
+              donate={donate}
+              excess={excess}
+              type={type}
+              name={name ?? ''}
+              id={id ?? ''}
+              previewMode={previewMode}
+              postcode={postcode}
             />
-          </div>
-        )}
-      </Card>
+            {postcode && (
+              <div className={styles.nearbyCharitiesTable}>
+                <hr />
+                <FindCharityTable postcode={postcode} type={type} currentCharityId={id} />
+              </div>
+            )}
+            {setPreview && (
+              <div className={styles.actionButtons}>
+                <FormButton
+                  theme="formButtonGrey"
+                  text="Edit profile"
+                  ariaLabel="edit profile"
+                  fullWidth={true}
+                  onClick={() => setPreview(false)}
+                />
+              </div>
+            )}
+          </Card>
+        </>
+      )}
     </>
   );
 };

--- a/src/components/PublicDashboard/__test__/PublicDashboard.test.tsx
+++ b/src/components/PublicDashboard/__test__/PublicDashboard.test.tsx
@@ -12,9 +12,12 @@ describe('Public dashboard', () => {
     );
     const { queryByText } = render(<Component />);
 
-    expect(
-      queryByText('We are still populating our profile, please check back later')
-    ).toBeInTheDocument();
+    expect(queryByText('We are still populating our profile')).toBeInTheDocument();
+    expect(queryByText('find nearby charities who may be able to help.')).toBeInTheDocument();
+    expect(queryByText('Check back later or you can also')).toBeInTheDocument();
+    expect(queryByText('Contact us')).toBeInTheDocument();
+    expect(queryByText('if you need help')).toBeInTheDocument();
+
     expect(queryByText('About us')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
- Change incomplete profile content
- Only show incomplete profile banner when not in preview mode

Connects to DC0518-638

Before:
![image](https://github.com/user-attachments/assets/114ae356-6b2b-48f9-9465-26ff90f7b9a5)

After:
<img width="1386" alt="Screenshot 2024-09-12 at 6 46 15 PM" src="https://github.com/user-attachments/assets/72786d63-4a95-41cf-ade9-428f66842824">

### While previewing page from the school/charity edit profile
<img width="1410" alt="Screenshot 2024-09-12 at 6 45 44 PM" src="https://github.com/user-attachments/assets/5a6cf0ca-0a0e-444f-9f92-1c830abe63b5">
